### PR TITLE
Add pytest and basic User model test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ typing_extensions==4.12.2
 Werkzeug==3.1.3
 Whoosh==2.7.4
 WTForms==3.2.1
+
+pytest==8.2.2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,24 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from app import app, db
+from app.models import User
+
+@pytest.fixture()
+def app_context():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+def test_user_creation(app_context):
+    with app_context.app_context():
+        user = User(name='Test User', email='test@example.com', password='secret')
+        db.session.add(user)
+        db.session.commit()
+        retrieved = User.query.filter_by(email='test@example.com').first()
+        assert retrieved is not None
+        assert retrieved.name == 'Test User'


### PR DESCRIPTION
## Summary
- add `pytest` to requirements
- create `tests/` directory
- verify user creation via SQLAlchemy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684822423c34832f85d0b78d892b34a7