### PR TITLE
Add confirmation validation for passwords

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -12,7 +12,10 @@ class SignupForm(FlaskForm):
             Length(min=8, message='Password must be at least 8 characters long.')
         ]
         )
-    confirm_password = PasswordField('Confirm Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(), EqualTo('password', message='Passwords must match')]
+    )
     submit = SubmitField('Submit')
 
 class SigninForm(FlaskForm):
@@ -40,7 +43,10 @@ class BandAdForm(FlaskForm):
 
 class NewPassword(FlaskForm):
     password = PasswordField('Password', validators=[DataRequired()])
-    confirm_password = PasswordField('Confirm Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(), EqualTo('password', message='Passwords must match')]
+    )
     submit = SubmitField('Submit')
 
 class TagPreferences(FlaskForm):

--- a/app/templates/profile_settings.html
+++ b/app/templates/profile_settings.html
@@ -14,6 +14,9 @@
             <div class="mb-3">
                 {{ passwordForm.confirm_password.label(class="form-label") }}
                 {{ passwordForm.confirm_password(class="form-control") }}
+                {% if passwordForm.confirm_password.errors %}
+                    <small class="text-danger">{{ passwordForm.confirm_password.errors[0] }}</small>
+                {% endif %}
             </div>
             {{ passwordForm.submit(class="btn btn-primary") }}
             </form>

--- a/app/templates/signin-signup.html
+++ b/app/templates/signin-signup.html
@@ -37,6 +37,9 @@
                         <div class="mb-3">
                             {{ form.confirm_password.label(class="form-label") }}
                             {{ form.confirm_password(class="form-control") }}
+                            {% if form.confirm_password.errors %}
+                                <small class="text-danger">{{ form.confirm_password.errors[0] }}</small>
+                            {% endif %}
                         </div>
                         {{ form.submit(class="btn btn-primary standard-btn") }}
                         <div class="message">


### PR DESCRIPTION
## Summary
- enforce matching passwords for signup and password change forms
- show validation errors for confirm password fields in templates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f104f3dc832f9c63afa84d70ec3d