### PR TITLE
Add access check for profile settings

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -275,6 +275,10 @@ def signin():
 
 @app.route('/profile_settings/<int:user_id>', methods=['GET', 'POST'])
 def profile_settings(user_id):
+    if not session.get('logged_in', False):
+        return redirect('/signin')
+    if session.get('user_id') != user_id:
+        return "Forbidden", 403
     passwordForm = NewPassword()
     if passwordForm.validate_on_submit():
         print("Form validated")

--- a/tests/test_profile_settings.py
+++ b/tests/test_profile_settings.py
@@ -1,0 +1,38 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from app import app, db
+from app.models import User
+
+@pytest.fixture()
+def client():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+def create_user(name="User", email="user@example.com"):
+    user = User(name=name, email=email, password="secret")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+def test_profile_settings_requires_login(client):
+    user = create_user()
+    response = client.get(f"/profile_settings/{user.id}", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/signin" in response.headers.get("Location", "")
+
+def test_profile_settings_forbidden_when_wrong_user(client):
+    user1 = create_user(name="User1", email="user1@example.com")
+    user2 = create_user(name="User2", email="user2@example.com")
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+        sess["user_id"] = user2.id
+    response = client.get(f"/profile_settings/{user1.id}")
+    assert response.status_code == 403
+


### PR DESCRIPTION
## Summary
- restrict `profile_settings` view to the logged in user
- add tests covering unauthorized access to profile settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f10fb9d0832f99d39407f64fe0a8