### PR TITLE
Add CSRF token meta tag and update JS

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
+    const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
+    const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : '';
    
     document.querySelectorAll('.like').forEach(function(button) {
         button.addEventListener('click', function() {
@@ -11,6 +13,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 type: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
                 },
                 success: (data) => {
                     if(data.error) {
@@ -45,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 type: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token() }}'
+                    'X-CSRFToken': csrfToken
                 },
                 success: (data) => {
                     if(data.success) {

--- a/app/templates/navbar_template.html
+++ b/app/templates/navbar_template.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>

--- a/app/templates/signin-signup.html
+++ b/app/templates/signin-signup.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
         <title>{{ title }}</title>


### PR DESCRIPTION
## Summary
- expose Flask CSRF token in page head
- read token from meta tag in static JS
- use token for like and register interest requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f11644d0832f8cbaa3da6890a97a