### PR TITLE
Check login for profile settings

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -275,6 +275,8 @@ def signin():
 
 @app.route('/profile_settings/<int:user_id>', methods=['GET', 'POST'])
 def profile_settings(user_id):
+    if not session.get('logged_in'):
+        return redirect('/signin')
     passwordForm = NewPassword()
     if passwordForm.validate_on_submit():
         print("Form validated")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from app import app, db
+
+@pytest.fixture()
+def client():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        with app.test_client() as client:
+            yield client
+        db.drop_all()
+
+def test_profile_settings_requires_login(client):
+    response = client.get('/profile_settings/1')
+    assert response.status_code == 302
+    assert '/signin' in response.headers['Location']
+
+def test_profile_settings_when_logged_in(client):
+    with client.session_transaction() as session:
+        session['logged_in'] = True
+        session['user_id'] = 1
+    response = client.get('/profile_settings/1')
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- require an authenticated session for `/profile_settings/<int:user_id>`
- add view tests for login requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f11a06e0832f931dc1653b11f45a