### PR TITLE
Initialize CSRF protection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_wtf.csrf import CSRFProtect
 import logging
 
 logging.basicConfig(
@@ -14,6 +15,7 @@ app.logger.setLevel(logging.DEBUG)
 db = SQLAlchemy(app)
 # Handles all migrations.
 migrate = Migrate(app, db)
+csrf = CSRFProtect(app)
 
 from app import views, models
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from werkzeug.security import generate_password_hash
 def app_context():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
     with app.app_context():
         db.create_all()
         yield app
@@ -29,8 +30,10 @@ def test_user_creation(app_context):
 
 def test_register_interest_once(app_context):
     with app_context.app_context():
-        user = User(name='User1', email='user1@example.com', password='pw')
-        owner = User(name='Owner', email='owner@example.com', password='pw')
+        user = User(name='User1', email='user1@example.com',
+                    password_hash=generate_password_hash('pw'))
+        owner = User(name='Owner', email='owner@example.com',
+                     password_hash=generate_password_hash('pw'))
         db.session.add_all([user, owner])
         db.session.commit()
 

--- a/tests/test_profile_settings.py
+++ b/tests/test_profile_settings.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pytest
 from app import app, db
 from app.models import User
+from werkzeug.security import generate_password_hash
 
 @pytest.fixture()
 def client():
@@ -16,7 +17,8 @@ def client():
         db.drop_all()
 
 def create_user(name="User", email="user@example.com"):
-    user = User(name=name, email=email, password="secret")
+    user = User(name=name, email=email,
+                password_hash=generate_password_hash("secret"))
     db.session.add(user)
     db.session.commit()
     return user


### PR DESCRIPTION
## Summary
- integrate `CSRFProtect` with the Flask app
- disable CSRF during tests and hash user passwords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa1a93178832f80d00f7c57386ddb