### PR TITLE
Add emails to band ad interest list

### DIFF
--- a/app/templates/interests.html
+++ b/app/templates/interests.html
@@ -6,7 +6,7 @@
             <div class="list-group">
                 {% for item in feed_items %}
                     <div class="list-group-item">
-                        <h3 class="mb-1">{{ item.user }}</h3>
+                        <h3 class="mb-1">{{ item.user }} <small class="text-muted">{{ item.email }}</small></h3>
                         <small class="text-muted">Interested on {{ item.date }}</small>
                     </div>
                 {% endfor %}

--- a/app/views.py
+++ b/app/views.py
@@ -116,15 +116,20 @@ def register_interest(ad_id):
 
 @app.route('/band_ad/<int:ad_id>/registered_interests', methods=['GET'])
 def registered_interests(ad_id):
+    band_ad = models.Bandad.query.get_or_404(ad_id)
+    if not session.get('logged_in', False) or session['user_id'] != band_ad.band.owner_id:
+        return "Forbidden", 403
+
     interests = models.Interest.query.filter_by(ad_id=ad_id).all()
     interest_items = [
         {
             "user": models.User.query.get(interest.user_id).name,
+            "email": models.User.query.get(interest.user_id).email,
             "date": interest.date.strftime("%d %b")
         }
         for interest in interests
     ]
-    feed_items = sorted(interest_items, key = lambda x: x['date'], reverse=True)
+    feed_items = sorted(interest_items, key=lambda x: x['date'], reverse=True)
     return render_template('interests.html', feed_items=feed_items, title="Interested users")
 
 @app.route('/newbandad', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- show each interested user's email address
- restrict viewing interested users to the band owner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab16f9e7c832f9a4bc7f11b9fd1ba