### PR TITLE
Add toggle for optional image field

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -67,6 +67,23 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
     });
+    if(window.location.pathname.includes('newpost')) {
+        const imageSwitch = document.getElementById('include-image');
+        const imageGroup = document.getElementById('image-url-group');
+        const imageInput = document.getElementById('image-input');
+        if(imageSwitch && imageGroup && imageInput) {
+            imageSwitch.addEventListener('change', function() {
+                if(this.checked) {
+                    imageGroup.classList.remove('d-none');
+                    imageInput.disabled = false;
+                } else {
+                    imageGroup.classList.add('d-none');
+                    imageInput.disabled = true;
+                    imageInput.value = '';
+                }
+            });
+        }
+    }
     if(window.location.pathname.includes('profile_settings')) {
         document.querySelector('input[name="url"]').addEventListener('input', function() {
             document.getElementById('profile-picture-preview').src = this.value;

--- a/app/templates/newband.html
+++ b/app/templates/newband.html
@@ -27,9 +27,13 @@
                     {{ form.content.label(class="form-label") }}
                     {{ form.content(class="form-control") }}
                 </div>
-                <div class="mb-3">
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="include-image">
+                    <label class="form-check-label" for="include-image">Include image</label>
+                </div>
+                <div class="mb-3 d-none" id="image-url-group">
                     {{ form.image.label(class="form-label") }}
-                    {{ form.image(class="form-control") }}
+                    {{ form.image(class="form-control", id="image-input", disabled=True) }}
                 </div>
                 <div class="mb-3">
                     {{ form.tag.label(class="form-label") }}


### PR DESCRIPTION
## Summary
- add optional image toggle on new post form
- hide image field initially
- show/hide image field via script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ab8d6e7b4832f821bc58380fa637b